### PR TITLE
Numerous fixes to config_from_env

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
+      coverage: 'codecov'
       envs: |
         - linux: py37
         - linux: py38

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info
 __pycache__
+.coverage
 .tox
 .vscode
 build

--- a/gcn_kafka/__init__.py
+++ b/gcn_kafka/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 from .core import Consumer, Producer
+from .env import config_from_env
 from ._version import version as __version__
 
-__all__ = ("Consumer", "Producer")
+__all__ = ("config_from_env", "Consumer", "Producer")

--- a/gcn_kafka/core.py
+++ b/gcn_kafka/core.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: CC0-1.0
 
-from __future__ import annotations
-import re
 from typing import Any, Mapping, Optional, Union
 try:
     from typing import Literal
@@ -53,32 +51,6 @@ def get_config(mode, config, **kwargs):
         config["group.id"] = str(uuid4())
 
     set_oauth_cb(config)
-    return config
-
-env_key_splitter = re.compile(r'_+')
-replacement_dict = {'_': '.', '__': '-', '___': '_'}
-
-def replacement(match: re.Match) -> str:
-    text = match[0]
-    return replacement_dict.get(text) or text
-
-
-def config_from_env(env: dict[str, str], prefix: str = 'KAFKA_') -> dict[str, str]:
-    """Construct a Kafka client configuration dictionary from env variables.
-    This uses the same rules as
-    https://docs.confluent.io/platform/current/installation/docker/config-reference.html
-    to convert from configuration variables to environment variable names:
-    * Start the environment variable name with the given prefix.
-    * Convert to upper-case.
-    * Replace periods (`.`) with single underscores (`_`).
-    * Replace dashes (`-`) with double underscores (`__`).
-    * Replace underscores (`-`) with triple underscores (`___`).
-    """
-    config = {}
-    for key, value in env.items():
-        if key.startswith(prefix):
-            key = env_key_splitter.sub(replacement, key.removeprefix(prefix))
-            config[key.lower()] = value
     return config
 
 

--- a/gcn_kafka/env.py
+++ b/gcn_kafka/env.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: CC0-1.0
+
+# FIXME: Remove after dropping support for Python 3.7
+from __future__ import annotations
+
+import os
+import re
+from typing import Optional
+
+env_key_splitter = re.compile(r'_+')
+replacement_dict = {'_': '.', '__': '-', '___': '_'}
+
+
+# Adapted from https://peps.python.org/pep-0616/
+# # FIXME: Remove after dropping support for Python 3.8
+def removeprefix(self: str, prefix: str) -> str:
+    if self.startswith(prefix):
+        return self[len(prefix):]
+    else:
+        return self[:]
+
+
+def replacement(match: re.Match) -> str:
+    text = match[0]
+    return replacement_dict.get(text) or text
+
+
+def config_from_env(env: Optional[dict[str, str]] = None, prefix: str = 'KAFKA_') -> dict[str, str]:
+    """Construct a Kafka client configuration dictionary from env variables.
+    This uses the same rules as
+    https://docs.confluent.io/platform/current/installation/docker/config-reference.html
+    to convert from configuration variables to environment variable names:
+    * Start the environment variable name with the given prefix.
+    * Convert to upper-case.
+    * Replace periods (`.`) with single underscores (`_`).
+    * Replace dashes (`-`) with double underscores (`__`).
+    * Replace underscores (`-`) with triple underscores (`___`).
+    """
+    if env is None:
+        env = os.environ
+    config = {}
+    for key, value in env.items():
+        if key.startswith(prefix):
+            key = env_key_splitter.sub(replacement, removeprefix(key, prefix))
+            config[key.lower()] = value
+    return config

--- a/gcn_kafka/test/test_env.py
+++ b/gcn_kafka/test/test_env.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: CC0-1.0
+
+import os
+
+from ..env import config_from_env
+
+
+def test_config_from_env(monkeypatch):
+    env = {'FOO_BAR_BAT__BAZ___': '123',
+           'XYZZ_BAR_BAT__BAZ___': '456'}
+
+    config = config_from_env(env, 'FOO_')
+    assert config == {'bar.bat-baz_': '123'}
+
+    monkeypatch.setattr(os, 'environ', env)
+
+    config = config_from_env(env, 'FOO_')
+    assert config == {'bar.bat-baz_': '123'}

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,7 @@ install_requires =
     typing-extensions; python_version<='3.7'
 packages = find:
 python_version = >=3.7
+
+[options.extras_require]
+test =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,9 @@ envlist = py{37,38,39}
 isolated_build = True
 
 [testenv]
-commands = python -c 'import gcn_kafka'
+deps =
+    pytest-cov
+extras =
+    test
+commands =
+    pytest gcn_kafka --cov


### PR DESCRIPTION
* Move to separate module
* `env` argument may be omitted, defaults to `os.environ`
* Add workaround for `str.removeprefix`, which was added in Python 3.9
* Move over unit tests, enable test suite in CI pipeline