### PR TITLE
Fig segfault when subscribing to non-existent topics.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "authlib",
     "certifi",
-    "confluent-kafka >= 1.6.1",
+    "confluent-kafka >= 1.6.1, != 2.1.0",
     "requests",
     "typing-extensions; python_version<='3.7'"
 ]


### PR DESCRIPTION
Work around a segfault that was introduced in
librdkafka/confluent-kafka-python 2.1.0 by disallowing that version as a dependency.

See https://github.com/confluentinc/librdkafka/pull/4245.

Fixes https://github.com/nasa-gcn/gcn-kafka-python/issues/17.