### PR TITLE
Disallow confluent-kafka-python 2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "authlib",
     "certifi",
-    "confluent-kafka >= 1.6.1, != 2.1.0",
+    "confluent-kafka >= 1.6.1, != 2.1.0, != 2.1.1",
     "requests",
     "typing-extensions; python_version<='3.7'"
 ]


### PR DESCRIPTION
Version 2.1.1 of confluent-kafka-python still suffers from a segfault bug. See https://github.com/confluentinc/confluent-kafka-python/issues/1547.