### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,19 +10,16 @@ jobs:
     with:
       coverage: 'codecov'
       envs: |
-        - linux: py37
         - linux: py38
         - linux: py39
         - linux: py310
         - linux: py311
         - linux: py312
-        - macos: py37
         - macos: py38
         - macos: py39
         - macos: py310
         - macos: py311
         - macos: py312
-        - windows: py37
         - windows: py38
         - windows: py39
         - windows: py310

--- a/gcn_kafka/core.py
+++ b/gcn_kafka/core.py
@@ -1,11 +1,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
-from typing import Any, Mapping, Optional, Union
-try:
-    from typing import Literal
-except ImportError:
-    # FIXME: Remove once we drop support for Python 3.7.
-    from typing_extensions import Literal
+from typing import Any, Literal, Mapping, Optional, Union
 from uuid import uuid4
 
 import certifi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,8 @@ dependencies = [
     "certifi",
     "confluent-kafka >= 2.2.0",
     "requests",
-    "typing-extensions; python_version<='3.7'"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = [ "version" ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}
+envlist = py{38,39,310,311}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Python 3.7 has reached end of life. See https://devguide.python.org/versions/.