### PR TITLE
Add record error handling to sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ consumer.subscribe(['gcn.classic.text.FERMI_GBM_FIN_POS',
                     'gcn.classic.text.LVC_INITIAL'])
 while True:
     for message in consumer.consume(timeout=1):
+        if message.error():
+            print(message.error())
+            continue
         print(message.value())
 ```
 


### PR DESCRIPTION
`Consumer.consume()` reports error messages by returning records with `message.error()` set. Without this error handling, the user's code is likely to raise an exception when it attempts to decode the value as if it was a normal record.

See also https://github.com/nasa-gcn/gcn-email/pull/116.