### PR TITLE
Require confluent-kafka >= 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "authlib",
     "certifi",
-    "confluent-kafka >= 1.6.1, != 2.1.0, != 2.1.1",
+    "confluent-kafka >= 2.2.0",
     "requests",
     "typing-extensions; python_version<='3.7'"
 ]


### PR DESCRIPTION
This version improves reliability of refreshing the authentication of long-lived sessions.

See https://github.com/confluentinc/librdkafka/pull/4301.