### PR TITLE
Reference third-party GitHub Actions workflows using hashes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   publish:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f  # v2.0.0
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       - uses: pre-commit/action@v3.0.1
   tox:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@d83bb11581e517f1e786ae76f146781fdd21cd2f  # v2.0.0
     with:
       coverage: 'codecov'
       envs: |


### PR DESCRIPTION
This is a supply chain security best practice.