### PR TITLE
Remove pre-commit GitHub Actions job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,6 @@ on:
   pull_request:
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-      - uses: pre-commit/action@v3.0.1
   tox:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:


### PR DESCRIPTION
We use the https://pre-commit.ci service to run our pre-commit hooks on pushed changes.