### PR TITLE
Convert test extra to a dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = [ "version" ]
 [project.urls]
 source = "https://github.com/nasa-gcn/gcn-kafka-python"
 
-[project.optional-dependencies]
+[dependency-groups]
 test = ["pytest"]
 
 [tool.setuptools_scm]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ isolated_build = True
 [testenv]
 deps =
     pytest-cov
-extras =
+dependency_groups =
     test
 commands =
     pytest --cov {posargs}


### PR DESCRIPTION
A dependency group is like an extra that is not published in the package metadata. The tests are not included in the package, so there is no reason to publish the test dependencies.